### PR TITLE
Add color field of the calendar plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.0 (IN PROGRESS)
+
+### Features / Enhancements
+
+- Select color for calender entry queries (#67)
+
 ## 1.1.0 (2022-12-12)
 
 ### Breaking changes

--- a/package.json
+++ b/package.json
@@ -34,5 +34,5 @@
     "upgrade": "yarn upgrade --latest",
     "watch": "grafana-toolkit plugin:dev --watch"
   },
-  "version": "1.1.0"
+  "version": "1.2.0"
 }

--- a/provisioning/dashboards/panels.json
+++ b/provisioning/dashboards/panels.json
@@ -66,12 +66,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "red",
                 "value": null
               },
               {
-                "color": "red",
-                "value": 80
+                "color": "yellow",
+                "value": 1000
+              },
+              {
+                "color": "green",
+                "value": 5000
               }
             ]
           }
@@ -90,7 +94,8 @@
         "descriptionField": "description",
         "quickLinks": true,
         "textField": "name",
-        "timeField": "updatedAt"
+        "timeField": "updatedAt",
+        "colorField": "downloads"
       },
       "targets": [
         {

--- a/src/components/CalendarPanel/CalendarPanel.tsx
+++ b/src/components/CalendarPanel/CalendarPanel.tsx
@@ -80,6 +80,7 @@ export const CalendarPanel: React.FC<Props> = ({ options, data, timeRange, width
    */
   const events = frames.flatMap((frame, frameIdx) => {
     const colorFn = frame.color?.display;
+
     return frame.text && frame.start
       ? Array.from({ length: frame.text.values.length })
           .map((_, i) => ({

--- a/src/components/CalendarPanel/CalendarPanel.tsx
+++ b/src/components/CalendarPanel/CalendarPanel.tsx
@@ -55,6 +55,7 @@ export const CalendarPanel: React.FC<Props> = ({ options, data, timeRange, width
     // No default for end time. If end time dimension isn't set, we assume that all events are instants.
     end: toTimeField(frame.fields.find((f) => f.name === options.endTimeField)),
     labels: frame.fields.filter((f) => options.labelFields?.includes(f.name)),
+    color: frame.fields.find((f) => f.name === options.colorField),
   }));
 
   /**
@@ -78,6 +79,7 @@ export const CalendarPanel: React.FC<Props> = ({ options, data, timeRange, width
    * Events
    */
   const events = frames.flatMap((frame, frameIdx) => {
+    const colorFn = frame.color?.display;
     return frame.text && frame.start
       ? Array.from({ length: frame.text.values.length })
           .map((_, i) => ({
@@ -87,13 +89,14 @@ export const CalendarPanel: React.FC<Props> = ({ options, data, timeRange, width
             end: frame.end?.values.get(i),
             labels: frame.labels?.map((field) => field.values.get(i)).filter((label) => label),
             links: frame.text?.getLinks!({ valueRowIndex: i }),
+            color: frame.color?.values.get(i),
           }))
-          .map<CalendarEvent>(({ text, description, labels, links, start, end }, i) => ({
+          .map<CalendarEvent>(({ text, description, labels, links, start, end, color }, i) => ({
             text,
             description,
             labels,
             start: dayjs(start),
-            color: classicColors[Math.floor(frameIdx % classicColors.length)],
+            color: colorFn?.(color).color ?? classicColors[Math.floor(frameIdx % classicColors.length)],
             links,
 
             // Set undefined if the user hasn't explicitly configured the dimension

--- a/src/module.ts
+++ b/src/module.ts
@@ -95,5 +95,16 @@ export const plugin = new PanelPlugin<CalendarOptions>(CalendarPanel).useFieldCo
         filterByType: [FieldType.string],
         multi: true,
       },
+    })
+    .addCustomEditor({
+      id: 'colorField',
+      path: 'colorField',
+      name: 'Color',
+      description: 'Fields to use as event color.',
+      editor: FieldSelectEditor,
+      category: ['Events'],
+      settings: {
+        multi: false,
+      },
     });
 });

--- a/src/types/panel.ts
+++ b/src/types/panel.ts
@@ -57,4 +57,11 @@ export interface CalendarOptions {
    * @type {boolean}
    */
   annotations?: boolean;
+
+  /**
+   * Color
+   *
+   * @type {string}
+   */
+  colorField?: string;
 }


### PR DESCRIPTION
1. Add an optional color field of the calendar panel definition.
2. Use the grafana field display function to get the filed color
3. Use 'download' as threshold in the test dashboard This change uses grafana builtin color features which supports threshold and/or value mappings

Fix #67