### PR TITLE
Fix events overlap when start date equals end date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Update ESLint configuration (#106)
 - Remove Grafana 8.5 support (#110)
 - Update to Grafana 10.0 (#110)
+- Fix events overlap when the start date equals the end date in Big Calendar (#112)
 
 ## 1.4.0 (2023-06-10)
 

--- a/provisioning/dashboards/panels.json
+++ b/provisioning/dashboards/panels.json
@@ -74,6 +74,90 @@
       "options": {
         "annotations": false,
         "autoScroll": true,
+        "calendarType": "legacy",
+        "colors": "event",
+        "descriptionField": "description",
+        "displayTime": true,
+        "labelFields": ["slug", "version"],
+        "quickLinks": false,
+        "textField": "name",
+        "timeField": "updatedAt"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 15,
+          "refId": "A"
+        }
+      ],
+      "title": "Calendar",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "id (count)"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "marcusolsson-calendar-panel"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [
+            {
+              "title": "Grafana Catalog",
+              "url": "${__data.fields.url}"
+            }
+          ],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1000
+              },
+              {
+                "color": "green",
+                "value": 5000
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 18,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 16,
+      "options": {
+        "annotations": false,
+        "autoScroll": true,
+        "calendarType": "bigCalendar",
         "colors": "event",
         "descriptionField": "description",
         "displayTime": true,
@@ -119,7 +203,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 36
       },
       "id": 14,
       "panels": [],
@@ -304,7 +388,7 @@
         "h": 30,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 37
       },
       "id": 15,
       "options": {
@@ -323,7 +407,7 @@
           }
         ]
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "cacheDurationSeconds": 300,

--- a/src/components/BigCalendar/BigCalendar.tsx
+++ b/src/components/BigCalendar/BigCalendar.tsx
@@ -97,6 +97,7 @@ export const BigCalendar: React.FC<Props> = ({ height, events, timeRange, onChan
       )}
       <Global styles={styles.global} />
       <Calendar
+        dayLayoutAlgorithm="no-overlap"
         localizer={localizer}
         events={calendarEvents}
         eventPropGetter={eventPropGetter}

--- a/src/hooks/useCalendarEvents.test.ts
+++ b/src/hooks/useCalendarEvents.test.ts
@@ -67,7 +67,7 @@ describe('Use Calendar Events', () => {
      * Check if end date of endless event is far enough
      */
     expect(calendarEvent1?.end).toBeInstanceOf(Date);
-    expect(calendarEvent1?.end?.toISOString()).toEqual(event1.start.toISOString());
+    expect(calendarEvent1?.end?.toISOString()).toEqual(event1.start.add(1, 'hours').toISOString());
 
     const calendarEvent2 = calendarEvents[1];
     expect(calendarEvent2).toEqual(

--- a/src/hooks/useCalendarEvents.ts
+++ b/src/hooks/useCalendarEvents.ts
@@ -10,7 +10,7 @@ export const useCalendarEvents = (events: CalendarEvent[]): Event[] => {
     return events.map<Event>(({ text, start, end, ...restEvent }) => ({
       title: text,
       start: start.toDate(),
-      end: end ? end.toDate() : end === null ? start.add(100, 'years').toDate() : start.toDate(),
+      end: end ? end.toDate() : end === null ? start.add(100, 'years').toDate() : start.add(1, 'hours').toDate(),
       resource: {
         isEndless: !end,
         ...restEvent,


### PR DESCRIPTION
Workaround: Event height fits around 1 hour so just added 1 hours for events with end = start to remove events overlap. 
<img width="1086" alt="Снимок экрана 2023-07-27 в 10 33 53" src="https://github.com/VolkovLabs/volkovlabs-calendar-panel/assets/15867703/4be28df3-eb68-4255-bf1b-eb3f5a680fc2">
