### PR TITLE
Fix calendar resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.0.0 (IN PROGRESS)
+## 2.0.0 (2023-07-27)
 
 ### Breaking changes
 
@@ -17,6 +17,7 @@
 - Add quick links for Big Calendar (#113)
 - Update back/next button for weekly and daily views in Big Calendar (#114)
 - Update button styles for Big Calendar (#115)
+- Update calendar resizing for Big Calendar (#116)
 
 ## 1.4.0 (2023-06-10)
 

--- a/src/components/BigCalendar/BigCalendar.tsx
+++ b/src/components/BigCalendar/BigCalendar.tsx
@@ -97,6 +97,7 @@ export const BigCalendar: React.FC<Props> = ({ height, events, timeRange, onChan
       )}
       <Global styles={styles.global} />
       <Calendar
+        key={height}
         localizer={localizer}
         events={calendarEvents}
         eventPropGetter={eventPropGetter}

--- a/src/module.ts
+++ b/src/module.ts
@@ -26,6 +26,11 @@ export const plugin = new PanelPlugin<CalendarOptions>(CalendarPanel)
     ],
   })
   .setPanelOptions((builder) => {
+    /**
+     * Visibility
+     */
+    const showForLegacy = (config: CalendarOptions) => config.calendarType === CalendarType.LEGACY;
+
     builder
       .addRadio({
         path: 'calendarType',
@@ -43,6 +48,7 @@ export const plugin = new PanelPlugin<CalendarOptions>(CalendarPanel)
           options: ScrollOptions,
         },
         defaultValue: DefaultOptions.autoScroll,
+        showIf: showForLegacy,
       })
       .addRadio({
         path: 'displayTime',
@@ -52,6 +58,7 @@ export const plugin = new PanelPlugin<CalendarOptions>(CalendarPanel)
           options: DisplayTimeOptions,
         },
         defaultValue: DefaultOptions.annotations,
+        showIf: showForLegacy,
       })
       .addRadio({
         path: 'quickLinks',


### PR DESCRIPTION
We can't trigger updating of visible events count for resize because component uses window resize event - https://github.com/jquense/react-big-calendar/blob/efc987bcf0e8f81bc861f6c5f65fa4e11d3b566d/src/Month.js#L52
So as a workaround is a passing height as a key for Calendar. It causes re-mount component on each height change. 