### PR TITLE
Set default language to en-US for Grafana 9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## 2.0.0 (2023-07-27)
+## 2.0.0 (2023-07-28)
 
 ### Breaking changes
 
-- Requires Grafana 9 and Grafana 10
+- Requires Grafana 9.2 and Grafana 10
 
 ### Features / Enhancements
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Calendar visualization panel is a Grafana plugin created to display calendar
 
 ## Requirements
 
-- **Grafana 9** and **Grafana 10** are required for major version 2.
+- **Grafana 9.2** and **Grafana 10** are required for major version 2.
 - **Grafana 8.5** and **Grafana 9** are required for major version 1.
 
 ## Getting Started

--- a/src/constants/default.ts
+++ b/src/constants/default.ts
@@ -9,6 +9,11 @@ export const enum Colors {
 }
 
 /**
+ * Language
+ */
+export const DefaultLanguage = 'en-US';
+
+/**
  * Default Options
  */
 export const DefaultOptions: CalendarOptions = {

--- a/src/hooks/useLocalizer.test.ts
+++ b/src/hooks/useLocalizer.test.ts
@@ -28,6 +28,15 @@ describe('Use Localizer', () => {
     expect(dayjs.locale()).toEqual('fr');
   });
 
+  it('Should set dayjs locale', () => {
+    config.bootData = {
+      user: {},
+    } as any;
+    renderHook(() => useLocalizer());
+
+    expect(dayjs.locale()).toEqual('en');
+  });
+
   it('Should set default dayjs locale', () => {
     config.bootData = {
       user: {

--- a/src/hooks/useLocalizer.ts
+++ b/src/hooks/useLocalizer.ts
@@ -8,6 +8,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { dayjsLocalizer } from 'react-big-calendar';
 import { getLocaleData } from '@grafana/data';
 import { config } from '@grafana/runtime';
+import { DefaultLanguage } from '../constants';
 
 /**
  * Dayjs locales per each grafana language
@@ -27,7 +28,7 @@ const dayjsLocales = {
  */
 export const useLocalizer = () => {
   const localeDate = getLocaleData();
-  const { language } = config.bootData.user;
+  const language = config.bootData.user.language || DefaultLanguage;
   const localeName = language.split('-')[0];
   const [dayjsLocale, setDayjsLocale] = useState(dayjsLocales.en);
 

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://github.com/grafana/grafana/raw/main/docs/sources/developers/plugins/plugin.schema.json",
   "dependencies": {
-    "grafanaDependency": ">=9.0.0",
+    "grafanaDependency": ">=9.2.0",
     "plugins": []
   },
   "id": "marcusolsson-calendar-panel",


### PR DESCRIPTION
1. Set default language to en-US for Grafana 9.2.
2. Update minimum version to Grafana 9.2.0