### PR TITLE
Add Big Calendar Language Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## 2.1.0 (IN PROGRESS)
+## 2.1.0 (2023-08-14)
 
 ### Features / Enhancements
 
 - Add Annotations type and limit (#121)
 - Update to Grafana 10.0.3 (#122)
+- Add Big Calendar Language Messages (#123)
 
 ## 2.0.1 (2023-08-03)
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,9 @@ grafana-cli plugins install marcusolsson-calendar-panel
 
 ## Highlights
 
-- Displays events in a Weekly or Monthly layout depending on the selected Time Range.
+- Displays events in a Monthly, Weekly and Daily layout.
 - Query calendar events from any data source.
-- Allows changing Time Range by clicking on days in the calendar.
-- Supports auto-scrolling to the end of the Time Range.
+- Allows changing Time Range.
 - Supports event colors based on Thresholds.
 - Allows opening data link instead of a sidebar when clicking an event.
 - Allows displaying Annotations across all dashboards for the selected Time Range.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ grafana-cli plugins install marcusolsson-calendar-panel
 | Section                  | Description                                             |
 | ------------------------ | ------------------------------------------------------- |
 | [Events](https://volkovlabs.io/plugins/volkovlabs-calendar-panel/events/)         | Explains how to set up a calendar to display your data. |
+| [Features](https://volkovlabs.io/plugins/volkovlabs-calendar-panel/features/)     | Demonstrates panel features.                            |
 | [Release Notes](https://volkovlabs.io/plugins/volkovlabs-calendar-panel/release/) | Stay up to date with the latest features and updates.   |
 
 ## Tutorial

--- a/src/components/BigCalendar/BigCalendar.test.tsx
+++ b/src/components/BigCalendar/BigCalendar.test.tsx
@@ -13,7 +13,7 @@ import { BigCalendar } from './BigCalendar';
  */
 jest.mock('../../hooks', () => ({
   ...jest.requireActual('../../hooks'),
-  useLocalizer: jest.fn(),
+  useLocalizer: jest.fn().mockImplementation(() => ({ localizer: jest.fn(), messages: {} }) as any),
 }));
 
 /**
@@ -120,7 +120,7 @@ describe('Big Calendar', () => {
       return null;
     });
 
-    jest.spyOn(window, 'open').mockImplementationOnce(() => ({} as any));
+    jest.spyOn(window, 'open').mockImplementationOnce(() => ({}) as any);
 
     const link = {
       href: 'http://123.com',
@@ -161,7 +161,7 @@ describe('Big Calendar', () => {
       return null;
     });
 
-    jest.spyOn(window, 'open').mockImplementationOnce(() => ({} as any));
+    jest.spyOn(window, 'open').mockImplementationOnce(() => ({}) as any);
 
     const link = {
       href: 'http://123.com',
@@ -202,7 +202,7 @@ describe('Big Calendar', () => {
       return null;
     });
 
-    jest.spyOn(window, 'open').mockImplementationOnce(() => ({} as any));
+    jest.spyOn(window, 'open').mockImplementationOnce(() => ({}) as any);
 
     const event: CalendarEvent = {
       text: 'hello',

--- a/src/components/BigCalendar/BigCalendar.tsx
+++ b/src/components/BigCalendar/BigCalendar.tsx
@@ -37,7 +37,7 @@ export const BigCalendar: React.FC<Props> = ({ height, events, timeRange, onChan
   /**
    * Localizer
    */
-  const localizer = useLocalizer();
+  const { localizer, messages } = useLocalizer();
 
   /**
    * Adopted Events for BigCalendar
@@ -117,6 +117,7 @@ export const BigCalendar: React.FC<Props> = ({ height, events, timeRange, onChan
         key={height}
         dayLayoutAlgorithm="no-overlap"
         localizer={localizer}
+        messages={messages}
         events={calendarEvents}
         eventPropGetter={eventPropGetter}
         startAccessor="start"

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,4 @@
 export * from './default';
+export * from './messages';
 export * from './options';
 export * from './tests';

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -1,0 +1,51 @@
+import { Messages } from 'react-big-calendar';
+
+/**
+ * Big Calendar Messages
+ */
+export const LanguageMessages: { [id: string]: Messages } = {
+  es: {
+    agenda: 'El Diario',
+    day: 'Día',
+    month: 'Mes',
+    next: 'Después',
+    previous: 'Atrás',
+    showMore: (total) => `+${total} más`,
+    today: 'Hoy',
+    week: 'Semana',
+    work_week: 'Semana de trabajo',
+  },
+  fr: {
+    agenda: 'Ordre du jour',
+    day: 'Jour',
+    month: 'Mois',
+    next: 'Prochain',
+    previous: 'Antérieur',
+    showMore: (total) => `+${total} plus`,
+    today: `Aujourd'hui`,
+    week: 'La semaine',
+    work_week: 'Semaine de travail',
+  },
+  de: {
+    agenda: 'Agenda',
+    day: 'Tag',
+    month: 'Monat',
+    next: 'Nächste',
+    previous: 'Vorherige',
+    showMore: (total) => `+${total} mehr`,
+    today: `Heute`,
+    week: 'Woche',
+    work_week: 'Arbeitswoche',
+  },
+  zh: {
+    agenda: '议程',
+    day: '天',
+    month: '月',
+    next: '下一个',
+    previous: '以前的',
+    showMore: (total) => `+${total} 更多的`,
+    today: `今天`,
+    week: '星期',
+    work_week: '工作周',
+  },
+};

--- a/src/hooks/useLocalizer.test.ts
+++ b/src/hooks/useLocalizer.test.ts
@@ -49,17 +49,17 @@ describe('Use Localizer', () => {
     expect(dayjs.locale()).toEqual('en');
   });
 
-  ['es-SP', 'fr-EN', 'de-GE', 'zh-CH'].forEach((lang) => {
-    it(`Should set messages for ${lang}`, () => {
+  ['es-SP', 'fr-EN', 'de-GE', 'zh-CH'].forEach((locale) => {
+    it(`Should set messages for ${locale}`, () => {
       config.bootData = {
         user: {
-          language: lang,
+          language: locale,
         },
       } as any;
       const { result } = renderHook(() => useLocalizer());
 
-      const locale = lang.split('-')[0]
-      const expectedMessages = LanguageMessages[locale];
+      const lang = locale.split('-')[0]
+      const expectedMessages = LanguageMessages[lang];
       expect(result.current.messages).toEqual(expectedMessages)
       if (result.current.messages.showMore && expectedMessages.showMore) {
         expect(result.current.messages.showMore(10)).toEqual(expectedMessages.showMore(10))

--- a/src/hooks/useLocalizer.test.ts
+++ b/src/hooks/useLocalizer.test.ts
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 import { config } from '@grafana/runtime';
 import { renderHook } from '@testing-library/react';
+import { LanguageMessages } from '../constants';
 import { useLocalizer } from './useLocalizer';
 
 /**
@@ -47,4 +48,23 @@ describe('Use Localizer', () => {
 
     expect(dayjs.locale()).toEqual('en');
   });
+
+  ['es-SP', 'fr-EN', 'de-GE', 'zh-CH'].forEach((lang) => {
+    it(`Should set messages for ${lang}`, () => {
+      config.bootData = {
+        user: {
+          language: lang,
+        },
+      } as any;
+      const { result } = renderHook(() => useLocalizer());
+
+      const locale = lang.split('-')[0]
+      const expectedMessages = LanguageMessages[locale];
+      expect(result.current.messages).toEqual(expectedMessages)
+      if (result.current.messages.showMore && expectedMessages.showMore) {
+        expect(result.current.messages.showMore(10)).toEqual(expectedMessages.showMore(10))
+      }
+    });
+  })
+
 });

--- a/src/hooks/useLocalizer.ts
+++ b/src/hooks/useLocalizer.ts
@@ -8,7 +8,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { dayjsLocalizer } from 'react-big-calendar';
 import { getLocaleData } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { DefaultLanguage } from '../constants';
+import { DefaultLanguage, LanguageMessages } from '../constants';
 
 /**
  * Dayjs locales per each grafana language
@@ -45,6 +45,7 @@ export const useLocalizer = () => {
       ...dayjsLocale,
       weekStart: localeDate.firstDayOfWeek(),
     });
-    return dayjsLocalizer(dayjs);
-  }, [dayjsLocale, localeDate]);
+
+    return { localizer: dayjsLocalizer(dayjs), messages: LanguageMessages[localeName] };
+  }, [dayjsLocale, localeDate, localeName]);
 };


### PR DESCRIPTION
Support native Grafana languages: English, Spanish, French, German and Simplified Chinese.

Based on Localization example: http://jquense.github.io/react-big-calendar/examples/index.html?path=/docs/examples--example-5